### PR TITLE
Fix a typo in fapp templates

### DIFF
--- a/snippets/controls.cson
+++ b/snippets/controls.cson
@@ -24,7 +24,7 @@
                     return render_template('${3:index}.html')
 
                 if __name__ == '__main__':
-                  app.run(host:'${4:127.0.0.1}', port=${5:8000}, debug=${6:True})\n$0 """
+                  app.run(host='${4:127.0.0.1}', port=${5:8000}, debug=${6:True})\n$0 """
 
     'Flask Route':
         'prefix': 'froute'


### PR DESCRIPTION
Equal sign should be used instead of the colon for passing
the default parameters.

Signed-off-by: Koren He <korenhe@outlook.com>